### PR TITLE
Update CORS policy to allow additional frontend URLs

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -92,7 +92,10 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
     {
-        policy.WithOrigins("http://localhost:3000") // Replace with your frontend's URL
+        policy.WithOrigins(
+            "http://localhost:3000", 
+            "https://cv-builder-git-test-igors-projects-baae4c6f.vercel.app",
+            "https://cv-builder-teal.vercel.app") // Replace with your frontend's URL
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();


### PR DESCRIPTION
The CORS policy in `Program.cs` has been updated to allow requests from two additional frontend URLs: `https://cv-builder-git-test-igors-projects-baae4c6f.vercel.app` and `https://cv-builder-teal.vercel.app`. This change ensures that the backend can accept requests from these specified frontend URLs, facilitating communication between the frontend and backend during development and testing.