### PR TITLE
Update SameSite attribute in AuthController cookies

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -69,8 +69,8 @@ public class AuthController : ControllerBase
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true, // Prevent JavaScript access
-            Secure = true, // Use HTTPS (set to false for local testing)
-            SameSite = SameSiteMode.Strict, // Prevent CSRF attacks
+            Secure = true,
+            SameSite = SameSiteMode.None,
             Expires = DateTime.UtcNow.AddHours(1)
         };
 


### PR DESCRIPTION
Modified the `SameSite` attribute of `CookieOptions` in the `AuthController` class from `SameSiteMode.Strict` to `SameSiteMode.None`. This change allows cookies to be sent with cross-site requests, which is necessary for certain authentication scenarios involving third-party services or APIs. The `Secure` attribute remains set to `true`, ensuring cookies are only sent over HTTPS.