### PR TITLE
Enforce secure cookies and immediate cookie expiration

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -78,7 +78,7 @@ public class AuthController : ControllerBase
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true, // Prevent JavaScript access
-            Secure = !isDevelopment,
+            Secure = true,
             SameSite = SameSiteMode.None,
             Path = "/",
             Expires = DateTime.UtcNow.AddHours(1)
@@ -122,7 +122,7 @@ public class AuthController : ControllerBase
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true,
-            Secure = !isDevelopment,
+            Secure = true,
             SameSite = SameSiteMode.None,
             Path = "/",
             Expires = DateTime.UtcNow.AddDays(-1)


### PR DESCRIPTION
Set Secure property of CookieOptions to true unconditionally to ensure cookies are always sent over HTTPS. Change Expires property to DateTime.UtcNow.AddDays(-1) to immediately invalidate and delete cookies.