### PR TITLE
Add environment-based cookie settings and logging

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -27,6 +27,7 @@ public class AuthController : ControllerBase
         _signInManager = signInManager;
         _configuration = configuration;
         _hostEnvironment = hostEnvironment;
+        Console.WriteLine($"EnvironmentName: {hostEnvironment.EnvironmentName}");
 
     }
 
@@ -73,13 +74,14 @@ public class AuthController : ControllerBase
             return Unauthorized(new { message = "Invalid credentials" });
 
         var token = GenerateJwtToken(user);
+        // Check if environment is Development
         var isDevelopment = _hostEnvironment.IsDevelopment();
 
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true, // Prevent JavaScript access
-            Secure = true,
-            SameSite = SameSiteMode.None,
+            Secure = !isDevelopment, // In Development, set Secure=false
+            SameSite = isDevelopment ? SameSiteMode.Lax : SameSiteMode.None,
             Path = "/",
             Expires = DateTime.UtcNow.AddHours(1)
         };
@@ -118,12 +120,13 @@ public class AuthController : ControllerBase
     [HttpPost("logout")]
     public IActionResult Logout()
     {
+        // Check if environment is Development
         var isDevelopment = _hostEnvironment.IsDevelopment();
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true,
-            Secure = true,
-            SameSite = SameSiteMode.None,
+            Secure = !isDevelopment, // In Development, set Secure=false
+            SameSite = isDevelopment ? SameSiteMode.Lax : SameSiteMode.None,
             Path = "/",
             Expires = DateTime.UtcNow.AddDays(-1)
         };


### PR DESCRIPTION
Introduce logging of the environment name in AuthController. Check if the app is in a development environment using _hostEnvironment.IsDevelopment(). Set Secure and SameSite properties of CookieOptions based on the environment:
  - In development: Secure = false, SameSite = Lax.
  - In production: Secure = true, SameSite = None. Apply these settings during login and logout processes.