### PR TITLE
Use UTC for JWT token expiration

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -111,7 +111,7 @@ public class AuthController : ControllerBase
             issuer: jwtSettings["Issuer"],
             audience: jwtSettings["Audience"],
             claims: claims,
-            expires: DateTime.Now.AddMinutes(Convert.ToDouble(jwtSettings["TokenExpiryInMinutes"])),
+            expires: DateTime.UtcNow.AddMinutes(Convert.ToDouble(jwtSettings["TokenExpiryInMinutes"])),
             signingCredentials: creds);
 
         return new JwtSecurityTokenHandler().WriteToken(token);


### PR DESCRIPTION
Updated the `expires` property of the `JwtSecurityToken` in `AuthController.cs` to use `DateTime.UtcNow` instead of `DateTime.Now`. This change ensures that the token expiration time is based on Coordinated Universal Time (UTC), avoiding issues related to time zone differences and daylight saving time changes.