### PR TITLE
Set JWT token expiration to a fixed 12 hours

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -111,7 +111,8 @@ public class AuthController : ControllerBase
             issuer: jwtSettings["Issuer"],
             audience: jwtSettings["Audience"],
             claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(Convert.ToDouble(jwtSettings["TokenExpiryInMinutes"])),
+            expires: DateTime.UtcNow.AddHours(12),
+            //expires: DateTime.UtcNow.AddMinutes(Convert.ToDouble(jwtSettings["TokenExpiryInMinutes"])),
             signingCredentials: creds);
 
         return new JwtSecurityTokenHandler().WriteToken(token);


### PR DESCRIPTION
Changed the JWT token expiration time in the AuthController class from a configurable value in minutes (based on jwtSettings["TokenExpiryInMinutes"]) to a fixed value of 12 hours. The original line using the configurable value has been commented out for reference.