### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe jQuery plugin

### DIFF
--- a/backend/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/backend/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1069,7 +1069,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.currentForm ).find( element ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/igorrooney/CVBuilder/security/code-scanning/7](https://github.com/igorrooney/CVBuilder/security/code-scanning/7)

To fix the problem, we need to ensure that any user input used in jQuery selectors is properly sanitized to prevent XSS attacks. This can be achieved by using jQuery's `find` method instead of directly using the input in a jQuery selector. The `find` method interprets the input as a CSS selector, which is safer.

- Modify the `validationTargetFor` function to use `find` method for selecting elements.
- Ensure that any other functions that use user input in jQuery selectors are also updated to use the `find` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
